### PR TITLE
Relative Referenzen in PharmDL-Verordnungen

### DIFF
--- a/PhDL_und_Impfen/Blutdruck/VerordnungApotheke_GKV.xml
+++ b/PhDL_und_Impfen/Blutdruck/VerordnungApotheke_GKV.xml
@@ -32,11 +32,11 @@
                     </coding>
                 </type>
                 <subject>
-                    <reference value="Patient/9c4dfaaf-2020-4571-a928-7740a223159d"/>
+                    <reference value="urn:uuid:9c4dfaaf-2020-4571-a928-7740a223159d"/>
                 </subject>
                 <date value="2024-02-02T08:30:00Z"/>
                 <author>
-                    <reference value="Practitioner/f94a85bf-aab8-4101-a599-507d9c261cc0"/>
+                    <reference value="urn:uuid:f94a85bf-aab8-4101-a599-507d9c261cc0"/>
                     <type value="Practitioner"/>
                 </author>
                 <author>
@@ -48,7 +48,7 @@
                 </author>
                 <title value="elektronische Arzneimittelverordnung"/>
                 <custodian>
-                    <reference value="Organization/7523efac-45a2-4001-a782-9cddca97fa8d"/>
+                    <reference value="urn:uuid:7523efac-45a2-4001-a782-9cddca97fa8d"/>
                 </custodian>
                 <section>
                     <code>
@@ -58,7 +58,7 @@
                         </coding>
                     </code>
                     <entry>
-                        <reference value="MedicationRequest/cc85b9f8-a7d5-4093-8845-89cf96591290"/>
+                        <reference value="urn:uuid:cc85b9f8-a7d5-4093-8845-89cf96591290"/>
                     </entry>
                 </section>
                 <section>
@@ -69,7 +69,7 @@
                         </coding>
                     </code>
                     <entry>
-                        <reference value="Coverage/3eda37cb-e3f0-412b-a3a4-e95fc15f1608"/>
+                        <reference value="urn:uuid:3eda37cb-e3f0-412b-a3a4-e95fc15f1608"/>
                     </entry>
                 </section>
             </Composition>
@@ -103,17 +103,17 @@
                 <status value="active"/>
                 <intent value="order"/>
                 <medicationReference>
-                    <reference value="Medication/f3b451b6-ef92-4888-82ec-762246bb52f0"/>
+                    <reference value="urn:uuid:f3b451b6-ef92-4888-82ec-762246bb52f0"/>
                 </medicationReference>
                 <subject>
-                    <reference value="Patient/9c4dfaaf-2020-4571-a928-7740a223159d"/>
+                    <reference value="urn:uuid:9c4dfaaf-2020-4571-a928-7740a223159d"/>
                 </subject>
                 <authoredOn value="2024-02-02"/>
                 <requester>
-                    <reference value="Practitioner/f94a85bf-aab8-4101-a599-507d9c261cc0"/>
+                    <reference value="urn:uuid:f94a85bf-aab8-4101-a599-507d9c261cc0"/>
                 </requester>
                 <insurance>
-                    <reference value="Coverage/3eda37cb-e3f0-412b-a3a4-e95fc15f1608"/>
+                    <reference value="urn:uuid:3eda37cb-e3f0-412b-a3a4-e95fc15f1608"/>
                 </insurance>
                 <dispenseRequest>
                     <quantity>
@@ -337,7 +337,7 @@
                     </coding>
                 </type>
                 <beneficiary>
-                    <reference value="Patient/9c4dfaaf-2020-4571-a928-7740a223159d"/>
+                    <reference value="urn:uuid:9c4dfaaf-2020-4571-a928-7740a223159d"/>
                 </beneficiary>
                 <payor>
                     <identifier>

--- a/PhDL_und_Impfen/Blutdruck/VerordnungApotheke_PKV.xml
+++ b/PhDL_und_Impfen/Blutdruck/VerordnungApotheke_PKV.xml
@@ -38,11 +38,11 @@
                     </coding>
                 </type>
                 <subject>
-                    <reference value="Patient/44b65f64-5c61-499e-a490-6978e028993f"/>
+                    <reference value="urn:uuid:44b65f64-5c61-499e-a490-6978e028993f"/>
                 </subject>
                 <date value="2024-02-02T08:30:00Z"/>
                 <author>
-                    <reference value="Practitioner/cbe731b2-c830-498c-80ea-ff9a053df00b"/>
+                    <reference value="urn:uuid:cbe731b2-c830-498c-80ea-ff9a053df00b"/>
                     <type value="Practitioner"/>
                 </author>
                 <author>
@@ -54,7 +54,7 @@
                 </author>
                 <title value="elektronische Arzneimittelverordnung"/>
                 <custodian>
-                    <reference value="Organization/544e9314-101c-4381-b0b8-883ad14605ba"/>
+                    <reference value="urn:uuid:544e9314-101c-4381-b0b8-883ad14605ba"/>
                 </custodian>
                 <section>
                     <code>
@@ -64,7 +64,7 @@
                         </coding>
                     </code>
                     <entry>
-                        <reference value="MedicationRequest/a946f47b-af8c-4d05-a686-2f71b3ef240d"/>
+                        <reference value="urn:uuid:a946f47b-af8c-4d05-a686-2f71b3ef240d"/>
                     </entry>
                 </section>
                 <section>
@@ -75,7 +75,7 @@
                         </coding>
                     </code>
                     <entry>
-                        <reference value="Coverage/61ea89ad-3c72-4b5e-8c33-80289dc1b8ab"/>
+                        <reference value="urn:uuid:61ea89ad-3c72-4b5e-8c33-80289dc1b8ab"/>
                     </entry>
                 </section>
             </Composition>
@@ -109,17 +109,17 @@
                 <status value="active"/>
                 <intent value="order"/>
                 <medicationReference>
-                    <reference value="Medication/27129fbe-03d1-4d65-a30c-22f36b7d3c49"/>
+                    <reference value="urn:uuid:27129fbe-03d1-4d65-a30c-22f36b7d3c49"/>
                 </medicationReference>
                 <subject>
-                    <reference value="Patient/44b65f64-5c61-499e-a490-6978e028993f"/>
+                    <reference value="urn:uuid:44b65f64-5c61-499e-a490-6978e028993f"/>
                 </subject>
                 <authoredOn value="2024-02-02"/>
                 <requester>
-                    <reference value="Practitioner/cbe731b2-c830-498c-80ea-ff9a053df00b"/>
+                    <reference value="urn:uuid:cbe731b2-c830-498c-80ea-ff9a053df00b"/>
                 </requester>
                 <insurance>
-                    <reference value="Coverage/61ea89ad-3c72-4b5e-8c33-80289dc1b8ab"/>
+                    <reference value="urn:uuid:61ea89ad-3c72-4b5e-8c33-80289dc1b8ab"/>
                 </insurance>
                 <dispenseRequest>
                     <quantity>
@@ -343,7 +343,7 @@
                     </coding>
                 </type>
                 <beneficiary>
-                    <reference value="Patient/44b65f64-5c61-499e-a490-6978e028993f"/>
+                    <reference value="urn:uuid:44b65f64-5c61-499e-a490-6978e028993f"/>
                 </beneficiary>
                 <payor>
                     <identifier>

--- a/PhDL_und_Impfen/Blutdruck/VerordnungApotheke_SKT.xml
+++ b/PhDL_und_Impfen/Blutdruck/VerordnungApotheke_SKT.xml
@@ -32,11 +32,11 @@
                     </coding>
                 </type>
                 <subject>
-                    <reference value="Patient/63cbc4b7-fde9-494f-8170-33d38d5942b3"/>
+                    <reference value="urn:uuid:63cbc4b7-fde9-494f-8170-33d38d5942b3"/>
                 </subject>
                 <date value="2024-02-02T08:30:00Z"/>
                 <author>
-                    <reference value="Practitioner/d0264f74-14dc-40bc-ab13-bb0cbca15284"/>
+                    <reference value="urn:uuid:d0264f74-14dc-40bc-ab13-bb0cbca15284"/>
                     <type value="Practitioner"/>
                 </author>
                 <author>
@@ -48,7 +48,7 @@
                 </author>
                 <title value="elektronische Arzneimittelverordnung"/>
                 <custodian>
-                    <reference value="Organization/e7c93d10-7c2e-4754-ab22-0ddcaee2aa50"/>
+                    <reference value="urn:uuid:e7c93d10-7c2e-4754-ab22-0ddcaee2aa50"/>
                 </custodian>
                 <section>
                     <code>
@@ -58,7 +58,7 @@
                         </coding>
                     </code>
                     <entry>
-                        <reference value="MedicationRequest/53bef5f6-8c87-4738-b105-13ec7d2ee64a"/>
+                        <reference value="urn:uuid:53bef5f6-8c87-4738-b105-13ec7d2ee64a"/>
                     </entry>
                 </section>
                 <section>
@@ -69,7 +69,7 @@
                         </coding>
                     </code>
                     <entry>
-                        <reference value="Coverage/1d607f61-1f2e-429b-9dfb-418e25be9cd2"/>
+                        <reference value="urn:uuid:1d607f61-1f2e-429b-9dfb-418e25be9cd2"/>
                     </entry>
                 </section>
             </Composition>
@@ -103,17 +103,17 @@
                 <status value="active"/>
                 <intent value="order"/>
                 <medicationReference>
-                    <reference value="Medication/594bd077-f626-4afb-9977-bce0102da383"/>
+                    <reference value="urn:uuid:594bd077-f626-4afb-9977-bce0102da383"/>
                 </medicationReference>
                 <subject>
-                    <reference value="Patient/63cbc4b7-fde9-494f-8170-33d38d5942b3"/>
+                    <reference value="urn:uuid:63cbc4b7-fde9-494f-8170-33d38d5942b3"/>
                 </subject>
                 <authoredOn value="2024-02-02"/>
                 <requester>
-                    <reference value="Practitioner/d0264f74-14dc-40bc-ab13-bb0cbca15284"/>
+                    <reference value="urn:uuid:d0264f74-14dc-40bc-ab13-bb0cbca15284"/>
                 </requester>
                 <insurance>
-                    <reference value="Coverage/1d607f61-1f2e-429b-9dfb-418e25be9cd2"/>
+                    <reference value="urn:uuid:1d607f61-1f2e-429b-9dfb-418e25be9cd2"/>
                 </insurance>
                 <dispenseRequest>
                     <quantity>
@@ -337,7 +337,7 @@
                     </coding>
                 </type>
                 <beneficiary>
-                    <reference value="Patient/63cbc4b7-fde9-494f-8170-33d38d5942b3"/>
+                    <reference value="urn:uuid:63cbc4b7-fde9-494f-8170-33d38d5942b3"/>
                 </beneficiary>
                 <payor>
                     <identifier>

--- a/PhDL_und_Impfen/Impfen/VerordnungApotheke.xml
+++ b/PhDL_und_Impfen/Impfen/VerordnungApotheke.xml
@@ -32,11 +32,11 @@
                     </coding>
                 </type>
                 <subject>
-                    <reference value="Patient/1a506270-a829-40e9-b176-6ea392bc5cda"/>
+                    <reference value="urn:uuid:1a506270-a829-40e9-b176-6ea392bc5cda"/>
                 </subject>
                 <date value="2024-02-01T10:00:00Z"/>
                 <author>
-                    <reference value="Practitioner/6fe19e28-f9f1-42fa-bb19-f539f8b2da16"/>
+                    <reference value="urn:uuid:6fe19e28-f9f1-42fa-bb19-f539f8b2da16"/>
                     <type value="Practitioner"/>
                 </author>
                 <author>
@@ -48,7 +48,7 @@
                 </author>
                 <title value="elektronische Arzneimittelverordnung"/>
                 <custodian>
-                    <reference value="Organization/e93d55ec-a43b-49da-8230-e6beb8ecd06a"/>
+                    <reference value="urn:uuid:e93d55ec-a43b-49da-8230-e6beb8ecd06a"/>
                 </custodian>
                 <section>
                     <code>
@@ -58,7 +58,7 @@
                         </coding>
                     </code>
                     <entry>
-                        <reference value="MedicationRequest/7a67dcc4-0e09-48a5-a66e-c3a893d68b8d"/>
+                        <reference value="urn:uuid:7a67dcc4-0e09-48a5-a66e-c3a893d68b8d"/>
                     </entry>
                 </section>
                 <section>
@@ -69,7 +69,7 @@
                         </coding>
                     </code>
                     <entry>
-                        <reference value="Coverage/14ce2e94-9a90-4dd2-b613-cf022baec9ab"/>
+                        <reference value="urn:uuid:14ce2e94-9a90-4dd2-b613-cf022baec9ab"/>
                     </entry>
                 </section>
             </Composition>
@@ -103,17 +103,17 @@
                 <status value="active"/>
                 <intent value="order"/>
                 <medicationReference>
-                    <reference value="Medication/e0b331c5-1c4f-45c5-8b25-1a639847975c"/>
+                    <reference value="urn:uuid:e0b331c5-1c4f-45c5-8b25-1a639847975c"/>
                 </medicationReference>
                 <subject>
-                    <reference value="Patient/1a506270-a829-40e9-b176-6ea392bc5cda"/>
+                    <reference value="urn:uuid:1a506270-a829-40e9-b176-6ea392bc5cda"/>
                 </subject>
                 <authoredOn value="2024-02-01"/>
                 <requester>
-                    <reference value="Practitioner/6fe19e28-f9f1-42fa-bb19-f539f8b2da16"/>
+                    <reference value="urn:uuid:6fe19e28-f9f1-42fa-bb19-f539f8b2da16"/>
                 </requester>
                 <insurance>
-                    <reference value="Coverage/14ce2e94-9a90-4dd2-b613-cf022baec9ab"/>
+                    <reference value="urn:uuid:14ce2e94-9a90-4dd2-b613-cf022baec9ab"/>
                 </insurance>
                 <dispenseRequest>
                     <quantity>
@@ -337,7 +337,7 @@
                     </coding>
                 </type>
                 <beneficiary>
-                    <reference value="Patient/1a506270-a829-40e9-b176-6ea392bc5cda"/>
+                    <reference value="urn:uuid:1a506270-a829-40e9-b176-6ea392bc5cda"/>
                 </beneficiary>
                 <payor>
                     <identifier>


### PR DESCRIPTION
Die Beispielverordnungen für die pharmazeutischen Dienstleistungen haben das gleiche Problem wie die alten Gematik-Quittungen: sie enthalten ungültige relative Referenzen (à la `Patient/666`) in Bündeleinträgen mit `fullUrl` vom Typ URN:UUID. Daher gibt es gar keine Basis-URLs, mit denen die relativen Referenzen zu absoluten Referenzen ergänzt werden könnten. Solche Referenzen sind gemäß FHIR-Semantik nicht auflösbar. 

Dazu kommt, daß die Ziele der Referenzen ebenfalls Bündeleinträge mit `fullUrl` vom Typ URN:UUID sind. Sie können daher gar nicht als Ziele von relativen Referenzen fungieren.

Die `id`-Elemente der Ressourcen in den Bündeleinträgen sind damit eigentlich überflüssig und haben unter der FHIR-Semantik keine Funktion. Sie sollten sie trotzdem genau in der jetzigen Form beibehalten werden - also jeweils mit der UUID aus `fullUrl` als Wert - damit der TA7-Konverter nicht abraucht.

Dieser PR ersetzt die relativen Referenzen durch absolute. Die geänderten Ressourcen werden sowohl vom Referenzvalidator also auch vom aktuellen HL7-Validator ([validator_cli.jar][validator_cli] 6.3.2) akzeptiert; die referentielle Integrität wurde mit einem geeigneten LINQPad-Skript geprüft (Firely-basiert).

[validator_cli]://github.com/hapifhir/org.hl7.fhir.core/releases