### PR TITLE
Korrektur MedicationDispense Profilversion (GKV) -> v1.3

### DIFF
--- a/PZN-Verordnung_Nr_28/PZN_Nr28_MedicationDispense.xml
+++ b/PZN-Verordnung_Nr_28/PZN_Nr28_MedicationDispense.xml
@@ -2,7 +2,7 @@
 <MedicationDispense xmlns="http://hl7.org/fhir">
     <id value="1b0ea6be-f64b-4f69-b387-4b2d7920320a"/>
     <meta>
-        <profile value="https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_PR_MedicationDispense|1.2"/>
+        <profile value="https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_PR_MedicationDispense|1.3"/>
         <tag>
             <display value="Beispiel MedicationDispense PZN Bsp 28"/>
         </tag>

--- a/PZN-Verordnung_Nr_29/PZN_Nr29_MedicationDispense.xml
+++ b/PZN-Verordnung_Nr_29/PZN_Nr29_MedicationDispense.xml
@@ -2,7 +2,7 @@
 <MedicationDispense xmlns="http://hl7.org/fhir">
     <id value="231209fc-eb80-41a6-83b2-654a6388875c"/>
     <meta>
-        <profile value="https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_PR_MedicationDispense|1.2"/>
+        <profile value="https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_PR_MedicationDispense|1.3"/>
         <tag>
             <display value="Beispiel MedicationDispense PZN Bsp 29"/>
         </tag>

--- a/PZN-Verordnung_Nr_30/PZN_Nr30_MedicationDispense.xml
+++ b/PZN-Verordnung_Nr_30/PZN_Nr30_MedicationDispense.xml
@@ -2,7 +2,7 @@
 <MedicationDispense xmlns="http://hl7.org/fhir">
     <id value="a66a7664-cdcb-4835-8588-578e3fd0d1bc"/>
     <meta>
-        <profile value="https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_PR_MedicationDispense|1.2"/>
+        <profile value="https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_PR_MedicationDispense|1.3"/>
         <tag>
             <display value="Beispiel MedicationDispense PZN Bsp 30"/>
         </tag>

--- a/PZN-Verordnung_Nr_31/PZN_Nr31_MedicationDispense.xml
+++ b/PZN-Verordnung_Nr_31/PZN_Nr31_MedicationDispense.xml
@@ -14,7 +14,7 @@
             <MedicationDispense>
                 <id value="8fdf05c2-0150-4c5e-a45c-3c300ca8d455"/>
                 <meta>
-                    <profile value="https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_PR_MedicationDispense|1.2"/>
+                    <profile value="https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_PR_MedicationDispense|1.3"/>
                     <tag>
                         <display value="Beispiel MedicationDispense PZN Bsp 28"/>
                     </tag>
@@ -118,7 +118,7 @@
             <MedicationDispense>
                 <id value="0455a017-acd8-47cf-9036-e9d9920ecf55"/>
                 <meta>
-                    <profile value="https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_PR_MedicationDispense|1.2"/>
+                    <profile value="https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_PR_MedicationDispense|1.3"/>
                     <tag>
                         <display value="Beispiel MedicationDispense PZN Bsp 28"/>
                     </tag>

--- a/PZN-Verordnung_Nr_32/PZN_Nr32_MedicationDispense.xml
+++ b/PZN-Verordnung_Nr_32/PZN_Nr32_MedicationDispense.xml
@@ -2,7 +2,7 @@
 <MedicationDispense xmlns="http://hl7.org/fhir">
     <id value="bf2ad9d0-91a7-4da1-8c3e-a856880b67da"/>
     <meta>
-        <profile value="https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_PR_MedicationDispense|1.2"/>
+        <profile value="https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_PR_MedicationDispense|1.3"/>
         <tag>
             <display value="Beispiel MedicationDispense PZN Bsp 32"/>
         </tag>

--- a/PZN-Verordnung_Nr_7/PZN_Nr7_MedicationDispense.xml
+++ b/PZN-Verordnung_Nr_7/PZN_Nr7_MedicationDispense.xml
@@ -90,5 +90,10 @@
       </identifier>
     </actor>
   </performer>
+  <quantity>
+    <value value="2" />
+    <system value="http://unitsofmeasure.org" />
+    <code value="{Package}" />
+  </quantity>
   <whenHandedOver value="2024-11-27"/>
 </MedicationDispense>

--- a/PZN_Mehrfachverordnung/PZN_MV_3/PZN_MV3_eAbgabedaten.html
+++ b/PZN_Mehrfachverordnung/PZN_MV_3/PZN_MV3_eAbgabedaten.html
@@ -121,7 +121,7 @@
 						63225
 						 
 						Langen</div><div><p><b>Abgabeinformationen für Abgabe</b> am
-							15.11.2023<br/><br/></p><table width="80%"><thead><tr><th>Position</th><th>PZN / SKZ /<br/>HMNR</th><th>Chargen-<br/>bezeichnung</th><th>Preiskomponente</th><th>Zusatzattribute</th></tr></thead><tbody><tr><td colspan="5"><b>Abrechnungszeilen</b></td></tr><tr><td colspan="3">gesamte Abgabe</td><td>15,16 
+							15.03.2025<br/><br/></p><table width="80%"><thead><tr><th>Position</th><th>PZN / SKZ /<br/>HMNR</th><th>Chargen-<br/>bezeichnung</th><th>Preiskomponente</th><th>Zusatzattribute</th></tr></thead><tbody><tr><td colspan="5"><b>Abrechnungszeilen</b></td></tr><tr><td colspan="3">gesamte Abgabe</td><td>15,16 
 		EUR<p class="abstand_links">
 			Gesamtzuzahlung: 
 			5,00 

--- a/PZN_Mehrfachverordnung/PZN_MV_3/PZN_MV3_eAbgabedaten.xml
+++ b/PZN_Mehrfachverordnung/PZN_MV_3/PZN_MV3_eAbgabedaten.xml
@@ -117,7 +117,7 @@
             <code value="Abgabeinformationen"/>
           </coding>
         </type>
-        <whenHandedOver value="2023-11-15"/>
+        <whenHandedOver value="2025-03-15"/>
       </MedicationDispense>
     </resource>
   </entry>


### PR DESCRIPTION
Die neuen GKV MedicationDispense.xml haben noch die alte Profiversion v1.2