### PR TITLE
Fix wg. Constraint "-for-adresszeilenAufbauPatientRessource-1"

### DIFF
--- a/PZN-Verordnung_Nr_32/PZN_Nr32_VerordnungArzt.xml
+++ b/PZN-Verordnung_Nr_32/PZN_Nr32_VerordnungArzt.xml
@@ -221,7 +221,7 @@
 				<birthDate value="2020-02-29"/>
 				<address>
 					<type value="both"/>
-					<line value="Roritzerstraße  1">
+					<line value="Roritzerstraße 1">
 						<extension url="http://hl7.org/fhir/StructureDefinition/iso21090-ADXP-streetName">
 							<valueString value="Roritzerstraße"/>
 						</extension>


### PR DESCRIPTION
Ein analoger Fix muß auf die gleiche Datei in den Zweigen [2025-01-15][250115] und [2025-10-01][251001] angewendet werden, in letzterem zusätzlich auch in der Erweiterung `iso21090-ADXP-streetName` (Leerzeichen am Ende).

Einen Pull-Request kann ich dafür nicht erstellen, weil man aus geforkten Repos PRs nur für den Hauptzweig ('main') machen kann.

[250115]: https://github.com/DAV-ABDA/eRezept-Beispiele/tree/2025-01-15
[251001]: https://github.com/DAV-ABDA/eRezept-Beispiele/tree/2025-10-01